### PR TITLE
Add travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/wolox-training/ec-node-js.svg?branch=master)](https://travis-ci.org/wolox-training/ec-node-js)
+
 # ec-node-js
 
 ## First steps


### PR DESCRIPTION
## Summary

- Add travis badge to README, it points to Master branch

## Known Issues

None

## Trello Card

None